### PR TITLE
feat: Add partial methods generation for changed and changing events

### DIFF
--- a/src/Maui.BindableProperty.Generator.Demo/CustomControls/HeaderControl.xaml.cs
+++ b/src/Maui.BindableProperty.Generator.Demo/CustomControls/HeaderControl.xaml.cs
@@ -84,5 +84,17 @@ namespace Maui.BindableProperty.Generator.Demo.CustomControls
         {
             // This method never will fired becuse the parameter is a different type
         }
+
+        partial void OnDisplayNameChanging(string value)
+        {
+            System.Diagnostics.Debug.WriteLine("Method OnDisplayNameChanging fired");
+            System.Diagnostics.Debug.WriteLine(value);
+        }
+
+        partial void OnDisplayNameChanged(string value)
+        {
+            System.Diagnostics.Debug.WriteLine("Method OnDisplayNameChanged fired");
+            System.Diagnostics.Debug.WriteLine(value);
+        }
     }
 }

--- a/src/Maui.BindableProperty.Generator/Core/BindableProperty/AutoBindablePropertyGenerator.cs
+++ b/src/Maui.BindableProperty.Generator/Core/BindableProperty/AutoBindablePropertyGenerator.cs
@@ -15,6 +15,7 @@ public class AutoBindablePropertyGenerator : IncrementalGeneratorBase, IIncremen
     private readonly List<Type> TypeImplementations = new() {
         typeof(DefaultValue),
         typeof(PropertyChanged),
+        typeof(PropertyChanging),
         typeof(DefaultBindingMode),
         typeof(ValidateValue)
     };
@@ -169,7 +170,7 @@ public class AutoBindablePropertyGenerator : IncrementalGeneratorBase, IIncremen
         var nameProperty = fieldSymbol.GetTypedConstant(attributeSymbol, AutoBindableConstants.AttrPropertyName);
         this.InitializeImplementations(fieldSymbol, attributeSymbol, classSymbol);
 
-        var propertyName = this.ChooseName(fieldName, nameProperty);
+        var propertyName = ChooseName(fieldName, nameProperty);
         if (propertyName?.Length == 0 || propertyName == fieldName)
         {
             context.ReportDiagnostic(
@@ -231,6 +232,9 @@ public class AutoBindablePropertyGenerator : IncrementalGeneratorBase, IIncremen
             }
         }
 
+        w._($@"partial void On{propertyName}Changed({declaringType.ToDisplayString(CommonSymbolDisplayFormat.DefaultFormat)} value);");
+        w._($@"partial void On{propertyName}Changing({declaringType.ToDisplayString(CommonSymbolDisplayFormat.DefaultFormat)} value);");
+
         this.ProcessImplementationLogic(w);
     }
 
@@ -273,7 +277,7 @@ public class AutoBindablePropertyGenerator : IncrementalGeneratorBase, IIncremen
         return this.Implementations.Any(i => i.SetterImplemented());
     }
 
-    private string ChooseName(string fieldName, TypedConstant overridenNameOpt)
+    internal static string ChooseName(string fieldName, TypedConstant overridenNameOpt)
     {
         if (!overridenNameOpt.IsNull)
         {

--- a/src/Maui.BindableProperty.Generator/Core/BindableProperty/AutoBindablePropertyGenerator.cs
+++ b/src/Maui.BindableProperty.Generator/Core/BindableProperty/AutoBindablePropertyGenerator.cs
@@ -232,9 +232,6 @@ public class AutoBindablePropertyGenerator : IncrementalGeneratorBase, IIncremen
             }
         }
 
-        w._($@"partial void On{propertyName}Changed({declaringType.ToDisplayString(CommonSymbolDisplayFormat.DefaultFormat)} value);");
-        w._($@"partial void On{propertyName}Changing({declaringType.ToDisplayString(CommonSymbolDisplayFormat.DefaultFormat)} value);");
-
         this.ProcessImplementationLogic(w);
     }
 

--- a/src/Maui.BindableProperty.Generator/Core/BindableProperty/Implementation/PropertyChanged.cs
+++ b/src/Maui.BindableProperty.Generator/Core/BindableProperty/Implementation/PropertyChanged.cs
@@ -62,7 +62,7 @@ public class PropertyChanged : IImplementation
         using (w.B(methodDefinition))
         {
             w._($@"var ctrl = ({this.ClassSymbol.ToDisplayString(CommonSymbolDisplayFormat.DefaultFormat)})bindable;");
-            this.OnChangedProperty.GetValue<string>((customMethodName) =>
+            if (this.OnChangedProperty.Value is string customMethodName)
             {
                 var methods = this.GetMethodsToCall(customMethodName);
                 if (methods.Any())
@@ -78,9 +78,15 @@ public class PropertyChanged : IImplementation
                             w._($@"ctrl.{customMethodName}(({this.FieldSymbol.Type})oldValue, ({this.FieldSymbol.Type})newValue);");
                     });
                 }
-                return default;
-            });
-            w._($@"ctrl.{methodName}(({this.FieldSymbol.Type})newValue);");
+            }
+            if (this.OnChangedProperty.Value is not string clashingCustomName || clashingCustomName != methodName)
+            {
+                w._($@"ctrl.{methodName}(({this.FieldSymbol.Type.ToDisplayString(CommonSymbolDisplayFormat.DefaultFormat)})newValue);");
+            }
+        }
+        if (this.OnChangedProperty.Value is not string clashingCustomCallName || clashingCustomCallName != methodName)
+        {
+            w._($@"partial void {methodName}({this.FieldSymbol.Type.ToDisplayString(CommonSymbolDisplayFormat.DefaultFormat)} value);");
         }
     }
 

--- a/src/Maui.BindableProperty.Generator/Core/BindableProperty/Implementation/PropertyChanging.cs
+++ b/src/Maui.BindableProperty.Generator/Core/BindableProperty/Implementation/PropertyChanging.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Maui.BindableProperty.Generator.Core.BindableProperty.Implementation;
+
+public class PropertyChanging : PropertyChanged
+{
+    public PropertyChanging(IFieldSymbol fieldSymbol, ISymbol attributeSymbol, INamedTypeSymbol classSymbol): base(fieldSymbol, attributeSymbol, classSymbol)
+    {
+        
+    }
+
+    public override string ProcessBindableParameters()
+    {
+        return $@"propertyChanging: {GetInternalMethodName()}";
+    }
+
+    protected override string GetInternalMethodName()
+    {
+        return $@"__{this.PropertyName}Changing";
+    }
+
+    protected override string GetMethodName()
+    {
+        return $@"On{this.PropertyName}Changing";
+    }
+
+    protected override IEnumerable<IMethodSymbol> GetMethodsToCall(string methodName)
+    {
+        return Enumerable.Empty<IMethodSymbol>();
+    }
+}

--- a/src/Maui.BindableProperty.Generator/Maui.BindableProperty.Generator.csproj
+++ b/src/Maui.BindableProperty.Generator/Maui.BindableProperty.Generator.csproj
@@ -15,10 +15,17 @@
 		<RepositoryUrl>https://github.com/rrmanzano/maui-bindableproperty-generator</RepositoryUrl>
 		<PackageId>M.BindableProperty.Generator</PackageId>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+		<IsRoslynComponent>true</IsRoslynComponent>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" PrivateAssets="all" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Maui.BindableProperty.Generator/Properties/launchSettings.json
+++ b/src/Maui.BindableProperty.Generator/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Debug": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\Maui.BindableProperty.Generator.Demo\\Maui.BindableProperty.Generator.Demo.csproj"
+    }
+  }
+}


### PR DESCRIPTION
Related to #12

![image](https://user-images.githubusercontent.com/5550089/233618875-e02297d8-37d5-4491-9cf4-c43d6d73c3e5.png)

Adds automatic generation for `On{PropertyName}Changed` and `On{PropertyName}Changing` partial methods called by the bindable property's `propertyChanged` and `propertyChanging` parameters respectively. This mimics the behaviour of the [MVVM Toolkit](https://learn.microsoft.com/en-us/dotnet/communitytoolkit/mvvm/generators/observableproperty#running-code-upon-changes).

No changes were made to the `OnChanged` attribute property, but no `OnChanging` property was added either. If the OnChanged string happens to clash with the partial method generation, it takes precedence and the partial method is not generated to avoid breaking changes

This has one drawback: A method is generated for each of `propertyChanged` and `propertyChanging` regardless of the partial methods being implemented or not. This might be solvable by checking of the class implements the partial methods if the impact of calling a noop method is something we want to avoid.
